### PR TITLE
fixed bug caused by fields updating when created

### DIFF
--- a/src/main/java/frc/lib/logfields/LogFieldsTable.java
+++ b/src/main/java/frc/lib/logfields/LogFieldsTable.java
@@ -38,13 +38,17 @@ public class LogFieldsTable implements LoggableInputs {
         createdTables.add(this);
     }
 
-    public static void updateAll() {
+    public static void updateAllTables() {
         for (LogFieldsTable fieldsTable : createdTables) {
-            if (fieldsTable.periodicBeforeFields != null && !Logger.getInstance().hasReplaySource()) {
-                fieldsTable.periodicBeforeFields.run();
-            }
-            Logger.getInstance().processInputs(fieldsTable.name, fieldsTable);
+            fieldsTable.update();
         }
+    }
+
+    public void update() {
+        if (periodicBeforeFields != null && !Logger.getInstance().hasReplaySource()) {
+            periodicBeforeFields.run();
+        }
+        Logger.getInstance().processInputs(name, this);
     }
 
     public LogFieldsTable getSubTable(String name) {
@@ -66,15 +70,11 @@ public class LogFieldsTable implements LoggableInputs {
     }
 
     public void setPeriodicBeforeFields(Runnable periodicRunnable) {
-        if(fields.isEmpty()){
-            periodicRunnable.run(); // so in the init cycle this will still run before the fields.
-        }
         this.periodicBeforeFields = periodicRunnable;
     }
 
     private <T extends LoggableInputs> T registerField(T field) {
         fields.add(field);
-        Logger.getInstance().processInputs(name, field); // so in the init cycle the value will still update and logged/replayed.
         return field;
     }
 

--- a/src/main/java/frc/lib/tuneables/sendableproperties/BooleanTuneableProperty.java
+++ b/src/main/java/frc/lib/tuneables/sendableproperties/BooleanTuneableProperty.java
@@ -25,6 +25,7 @@ public class BooleanTuneableProperty extends TuneableProperty {
             valueFromNetwork = new boolean[] {};
             return newValue;
         });
+        fieldsTable.update();
 
         sendableBuilder.addBooleanProperty(key, getter, value -> valueFromNetwork = new boolean[] { value });
     }

--- a/src/main/java/frc/lib/tuneables/sendableproperties/NumberTuneableProperty.java
+++ b/src/main/java/frc/lib/tuneables/sendableproperties/NumberTuneableProperty.java
@@ -25,6 +25,7 @@ public class NumberTuneableProperty extends TuneableProperty {
             valueFromNetwork = new double[] {};
             return newValue;
         });
+        fieldsTable.update();
 
         sendableBuilder.addDoubleProperty(key, getter, value -> valueFromNetwork = new double[] { value });
     }

--- a/src/main/java/frc/lib/tuneables/sendableproperties/StringTuneableProperty.java
+++ b/src/main/java/frc/lib/tuneables/sendableproperties/StringTuneableProperty.java
@@ -24,6 +24,7 @@ public class StringTuneableProperty extends TuneableProperty {
             valueFromNetwork = new String[] {};
             return newValue;
         });
+        fieldsTable.update();
 
         sendableBuilder.addStringProperty(key, getter, value -> valueFromNetwork = new String[] { value });
     }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -87,7 +87,7 @@ public class Robot extends LoggedRobot {
 
     @Override
     public void robotPeriodic() {
-        LogFieldsTable.updateAll();
+        LogFieldsTable.updateAllTables();
         TuneablesManager.update();
         CommandScheduler.getInstance().run();
     }


### PR DESCRIPTION
Because fields were updated when created, meaning they called the value supplier before the IO constructor was called, sometimes objects used in the supplier that are initialized in the IO constructor were null thus creating NullPointerExeption.
Because of that problem, this feature was disabled, and instead, you can now call `update()` on the fields table manually.